### PR TITLE
Removing links to the Structural namespace

### DIFF
--- a/IES_Engine/Convert/ToBHoM.cs
+++ b/IES_Engine/Convert/ToBHoM.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using BHE = BH.oM.Environment;
-using BHS = BH.oM.Structural;
 using BHG = BH.oM.Geometry;
 using BH.oM.Environment.Properties;
 using BH.oM.Environment.Elements;

--- a/IES_Engine/Convert/ToGbXML.cs
+++ b/IES_Engine/Convert/ToGbXML.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using BH.oM.Base;
 using BHE = BH.oM.Environment;
-using BHS = BH.oM.Structural;
 using BH.oM.Environment.Elements;
 using BH.oM.Environment.Properties;
 using BH.oM.Environment.Interface;

--- a/IES_Engine/Convert/ToIES.cs
+++ b/IES_Engine/Convert/ToIES.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using BH.oM.Base;
 using BHE = BH.oM.Environment;
-using BHS = BH.oM.Structural;
 using BH.oM.Environment.Elements;
 using BH.oM.Environment.Properties;
 using BH.oM.Environment.Interface;


### PR DESCRIPTION
Fixes #21.

Maybe dependent on https://github.com/BuroHappoldEngineering/BHoM/pull/259 but realistically, this is removing the link so should work without that branch/PR.