### PR TITLE
Update IESFileSettings

### DIFF
--- a/IES_Adapter/IESAdapter.cs
+++ b/IES_Adapter/IESAdapter.cs
@@ -24,7 +24,7 @@ namespace BH.Adapter.IES
         [Description("Produces an IES Adapter to allow interopability with IES GEM files and the BHoM")]
         [Input("iesFileSettings", "Input the file settings the IES Adapter should use, default null")]
         [Output("adapter", "Adapter to IES GEM")]
-        public IESAdapter(IESFileSettings iesFileSettings = null)
+        public IESAdapter(FileSettingsIES iesFileSettings = null)
         {
             if(iesFileSettings == null)
             {
@@ -85,7 +85,7 @@ namespace BH.Adapter.IES
         /**** Public properties                         ****/
         /***************************************************/
 
-        private IESFileSettings _fileSettings { get; set; } = null;
+        private FileSettingsIES _fileSettings { get; set; } = null;
     }
 }
 

--- a/IES_Engine/Create/FileSettingsIES.cs
+++ b/IES_Engine/Create/FileSettingsIES.cs
@@ -21,7 +21,7 @@ namespace BH.Engine.IES
         [Input("fileName", "Name of GEM file, not including the file extension. Default 'BHoM_GEM_File'")]
         [Input("directory", "Path to GEM file. Defaults to your desktop")]
         [Output("fileSettings", "The file settings to use with the IES adapter for pull and push")]
-        public static IESFileSettings IESFileSettings(string fileName = "BHoM_GEM_File", string directory = null)
+        public static FileSettingsIES FileSettingsIES(string fileName = "BHoM_GEM_File", string directory = null)
         {
             if (directory == null)
                 directory = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Desktop);
@@ -32,7 +32,7 @@ namespace BH.Engine.IES
                 return null;
             }
 
-            return new IESFileSettings
+            return new FileSettingsIES
             {
                 Directory = directory,
                 FileName = fileName,

--- a/IES_Engine/IES_Engine.csproj
+++ b/IES_Engine/IES_Engine.csproj
@@ -88,7 +88,7 @@
     <Compile Include="Convert\Environment_oM\OpeningType.cs" />
     <Compile Include="Convert\Environment_oM\Space.cs" />
     <Compile Include="Convert\Geometry_oM\Point.cs" />
-    <Compile Include="Create\IESFileSettings.cs" />
+    <Compile Include="Create\FileSettingsIES.cs" />
     <Compile Include="Modify\RepairOpening.cs" />
     <Compile Include="Modify\RoundedPoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/IES_Engine/Query/FullFileName.cs
+++ b/IES_Engine/Query/FullFileName.cs
@@ -14,7 +14,7 @@ namespace BH.Engine.IES
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FullFileName(this IESFileSettings fileSettings)
+        public static string FullFileName(this FileSettingsIES fileSettings)
         {
             return System.IO.Path.Combine(fileSettings.Directory, fileSettings.FileName + ".gem");
         }

--- a/IES_oM/FileSettingsIES.cs
+++ b/IES_oM/FileSettingsIES.cs
@@ -4,7 +4,7 @@ using BH.oM.Base;
 
 namespace BH.oM.IES.Settings
 {
-    public class IESFileSettings : BHoMObject
+    public class FileSettingsIES : BHoMObject
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/IES_oM/IES_oM.csproj
+++ b/IES_oM/IES_oM.csproj
@@ -47,7 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="IESFileSettings.cs" />
+    <Compile Include="FileSettingsIES.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #46 


### Test Script
N/A - just go a `ctrl` `shift` `b` search on GH canvas and it should now be `FileSettingsIES` instead of `ESFileSettings`

The `I` was being cut off presumably because reflection assumed it was then an interface type. This has been rectified by this PR.