### PR TITLE
Fix 2019 gem pull

### DIFF
--- a/IES_Adapter/CRUD/Read.cs
+++ b/IES_Adapter/CRUD/Read.cs
@@ -73,7 +73,15 @@ namespace BH.Adapter.IES
 
             sr.Close();
 
-            iesStrings.RemoveRange(0, 10); //Remove the first 10 items...
+            int numbersOfSkip = 10;
+
+            if (iesStrings.First() != "LAYER") //Check if it is a 2019 GEM file
+            {
+                iesStrings.RemoveRange(0, 4);
+                numbersOfSkip = 12;
+            }
+
+            iesStrings.RemoveRange(0, numbersOfSkip); //Remove the first 10 items...
             bool endOfFile = false;
             while(!endOfFile)
             {
@@ -91,7 +99,7 @@ namespace BH.Adapter.IES
                 objects.AddRange(space.FromIES(_settingsIES));
 
                 if(!endOfFile)
-                    iesStrings.RemoveRange(0, nextIndex + 10);
+                    iesStrings.RemoveRange(0, nextIndex + numbersOfSkip);
             }
 
             return objects;

--- a/IES_Adapter/CRUD/Read.cs
+++ b/IES_Adapter/CRUD/Read.cs
@@ -73,15 +73,15 @@ namespace BH.Adapter.IES
 
             sr.Close();
 
-            int numbersOfSkip = 10;
+            int linesToSkip = 10;
 
             if (iesStrings.First() != "LAYER") //Check if it is a 2019 GEM file
             {
                 iesStrings.RemoveRange(0, 4);
-                numbersOfSkip = 12;
+                linesToSkip = 12;
             }
 
-            iesStrings.RemoveRange(0, numbersOfSkip); //Remove the first 10 items...
+            iesStrings.RemoveRange(0, linesToSkip); //Remove the first 10 items...
             bool endOfFile = false;
             while(!endOfFile)
             {
@@ -99,7 +99,7 @@ namespace BH.Adapter.IES
                 objects.AddRange(space.FromIES(_settingsIES));
 
                 if(!endOfFile)
-                    iesStrings.RemoveRange(0, nextIndex + numbersOfSkip);
+                    iesStrings.RemoveRange(0, nextIndex + linesToSkip);
             }
 
             return objects;

--- a/IES_Engine/Convert/Geometry/Point.cs
+++ b/IES_Engine/Convert/Geometry/Point.cs
@@ -57,7 +57,7 @@ namespace BH.Engine.IES
             try
             {
                 iesPt = iesPt.Trim();
-                string[] split = iesPt.Split(' ');
+                string[] split = System.Text.RegularExpressions.Regex.Split(iesPt, @"\s+");
                 return new Point
                 {
                     X = System.Convert.ToDouble(split[0]),


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #135 

 <!-- Add short description of what has been fixed -->
The file format has changes for the 2019 GEM from previous versions. These changes make a pull possible from both the new and older versions of a gem file. 

 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Test Files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FIES%5FToolkit%2FIES%5F2019%20Pull)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->