### PR TITLE
Pull space objects from IES GEM

### DIFF
--- a/IES_Adapter/IES_Adapter.csproj
+++ b/IES_Adapter/IES_Adapter.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -32,52 +32,55 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Adapter_Engine">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Adapter_oM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Analytical_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Adapter">
-<HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
-<HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Dimensional_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Environment_Engine">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Environment_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Environment_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Environment_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Environment_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Environment_oM.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Geometry_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Dynamic, Version=1.1.2.22, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
@@ -98,12 +101,12 @@
     </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/IES_Adapter/IES_Adapter.csproj
+++ b/IES_Adapter/IES_Adapter.csproj
@@ -77,6 +77,7 @@
     </Reference>
     <Reference Include="Geometry_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/IES_Engine/Convert/Environment/Space.cs
+++ b/IES_Engine/Convert/Environment/Space.cs
@@ -188,13 +188,21 @@ namespace BH.Engine.Adapters.IES
                 panels.Add(panel);
             }
 
-            //Fix the openings now
-            foreach(Panel p in panels)
+            if (settingsIES.PullOpenings)
             {
-                for (int x = 0; x < p.Openings.Count; x++)
+                //Fix the openings now
+                foreach (Panel p in panels)
                 {
-                    p.Openings[x] = p.Openings[x].RepairOpening(p, panels);
+                    for (int x = 0; x < p.Openings.Count; x++)
+                    {
+                        p.Openings[x] = p.Openings[x].RepairOpening(p, panels);
+                    }
                 }
+            }
+            else
+            {
+                foreach(Panel p in panels)
+                    p.Openings = new List<Opening>();
             }
 
             return panels;

--- a/IES_Engine/Modify/RepairOpening.cs
+++ b/IES_Engine/Modify/RepairOpening.cs
@@ -64,6 +64,12 @@ namespace BH.Engine.Adapters.IES
             Point panelBottomLeftReference = host.BottomLeft(panelsAsSpace);
             Point panelTopRightReference = host.TopRight(panelsAsSpace);
 
+            if(panelBottomRightReference == null || panelBottomLeftReference == null || panelTopRightReference == null)
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("An error occurred in attempting to repair opening with GUID " + opening.BHoM_Guid + " hosted by the panel with GUID " + host.BHoM_Guid + " . The opening on this panel may not be correctly pulled and should be investigated.");
+                return opening;
+            }
+
             Vector xVector = panelBottomLeftReference - panelBottomRightReference;
             xVector.Z = 0;
             Vector yVector = panelTopRightReference - panelBottomRightReference;

--- a/IES_oM/SettingsIES.cs
+++ b/IES_oM/SettingsIES.cs
@@ -40,6 +40,9 @@ namespace BH.oM.IES.Settings
         [Description("Set how many decimal places coordinates should have on export, default is set to 6")]
         public virtual int DecimalPlaces { get; set; } = 6;
 
+        [Description("Determine whether or not openings should be pulled from the GEM file when pulling a GEM file. Only valid if pulling Panels which host openings. Default is True, to pull openings when pulling panels.")]
+        public virtual bool PullOpenings { get; set; } = true;
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #144 


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
Allows for a `FilterRequest` of type `Space` to be applied and retrieve only the space objects.
Also allows for pulling of panels without openings, if desired.