### PR TITLE
Removing reference to the deprecated Centre() method

### DIFF
--- a/IES_Adapter/CRUD/Read.cs
+++ b/IES_Adapter/CRUD/Read.cs
@@ -138,7 +138,7 @@ namespace BH.Adapter.IES
             foreach (List<Panel> space in panelsAsSpaces)
             {
                 Polyline perim = space.FloorGeometry();
-                Point centre = perim != null ? perim.Centre() : null;
+                Point centre = perim != null ? perim.Centroid() : null;
 
                 if (perim == null)
                     BH.Engine.Reflection.Compute.RecordWarning("The space " + space.ConnectedSpaceName() + " did not return a valid floor geometry from its panels. The geometry is null but the space has been pulled. You may wish to investigate and fix manually.");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
[#2263](https://github.com/BHoM/BHoM_Engine/pull/2263) Main pull request in the Geometry_Engine.

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Replacing reference to `Centre()` with `Centroid()`.

### Changelog
- Updating `Read` method to call for `Centroid` instead of `Centre`.