### PR TITLE
Added configuration regarding usage of AdapterId mechanism

### DIFF
--- a/IES_Adapter/IESAdapter.cs
+++ b/IES_Adapter/IESAdapter.cs
@@ -42,10 +42,10 @@ namespace BH.Adapter.IES
         /**** Constructors                              ****/
         /***************************************************/
 
-        [Description("Produces an IES Adapter to allow interopability with IES GEM files and the BHoM")]
-        [Input("fileSettings", "Input fileSettings to get the file name and directory the IES Adapter should use")]
+        [Description("Produces an IES Adapter to allow interopability with IES GEM files and the BHoM.")]
+        [Input("fileSettings", "Input fileSettings to get the file name and directory the IES Adapter should use.")]
         [Input("settingsIES", "Input additional settings the adapter should use.")]
-        [Output("adapter", "Adapter to IES GEM")]
+        [Output("adapter", "Adapter to IES GEM.")]
         public IESAdapter(BH.oM.Adapter.FileSettings fileSettings = null, SettingsIES settingsIES = null)
         {
             // This asks the base adapter to only Create the objects.

--- a/IES_Adapter/IESAdapter.cs
+++ b/IES_Adapter/IESAdapter.cs
@@ -50,6 +50,7 @@ namespace BH.Adapter.IES
         {
             // This asks the base adapter to only Create the objects.
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
+            m_AdapterSettings.UseAdapterId = false;
 
             if (fileSettings == null)
             {


### PR DESCRIPTION
Set adapterID to false to address issue #213
Closes #213 

Due to recent changes in how the adapters work, an error is now thrown if the adapterID is neither implemented or set to false. 