### PR TITLE
Fix pull openings and reading a BHoM GEM file by fixing the push of the GEM file

### DIFF
--- a/IES_Adapter/CRUD/Create.cs
+++ b/IES_Adapter/CRUD/Create.cs
@@ -57,6 +57,11 @@ namespace BH.Adapter.IES
 
             StreamWriter sw = new StreamWriter(_fileSettings.GetFullFileName());
 
+            sw.WriteLine("COM GEM data file exported by BHoM");
+            sw.WriteLine("CAT"); //Lol - Default GEM files use ANT
+            sw.WriteLine("SITE");
+            sw.WriteLine("51.378  2.3648  0.000  0.000");
+
             try
             {
                 foreach (List<Panel> space in panelsAsSpaces)

--- a/IES_Adapter/CRUD/Create.cs
+++ b/IES_Adapter/CRUD/Create.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.IES
             sw.WriteLine("COM GEM data file exported by BHoM");
             sw.WriteLine("CAT"); //Lol - Default GEM files use ANT
             sw.WriteLine("SITE");
-            sw.WriteLine("51.378  2.3648  0.000  0.000");
+            sw.WriteLine("51.378  2.3648  0.000  0.000");
 
             try
             {

--- a/IES_Adapter/Convert/Environment/Space.cs
+++ b/IES_Adapter/Convert/Environment/Space.cs
@@ -177,7 +177,8 @@ namespace BH.Adapter.IES
                     for (int x = 0; x < numCoords; x++)
                         openingPts.Add(iesSpace[count + x]);
 
-                    panel.Openings.Add(openingPts.FromIESOpening(openingData.Split(' ')[1], pLine, settingsIES));
+                    if(settingsIES.PullOpenings)
+                        panel.Openings.Add(openingPts.FromIESOpening(openingData.Split(' ')[1], pLine, settingsIES));
 
                     count += numCoords;
                     countOpenings++;


### PR DESCRIPTION
Fixes #217 
Fixes #218

Fix for #218 is provided by fixing the push of the BHoM GEM file to include data which was previously missing.