### PR TITLE
Functional tests for pushing panels

### DIFF
--- a/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
+++ b/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
@@ -57,7 +57,9 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_Engine">
-      <HintPath>..\..\..\..\..\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Data_Engine.dll</HintPath>
+		<Private>True</Private>
+		<SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>

--- a/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
+++ b/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
@@ -71,6 +71,16 @@
       <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="File_Engine">
+      <HintPath>$(ProgramData)\BHoM\Assemblies\File_Engine.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="File_oM">
+      <HintPath>$(ProgramData)\BHoM\Assemblies\File_oM.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Geometry_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>True</Private>

--- a/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
+++ b/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
@@ -58,8 +58,8 @@
     </Reference>
     <Reference Include="Data_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_Engine.dll</HintPath>
-		<Private>True</Private>
-		<SpecificVersion>False</SpecificVersion>
+      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>

--- a/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
+++ b/.ci/unit-tests/IES_Adapter_Test/IES_Adapter_Test.csproj
@@ -56,6 +56,9 @@
       <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="Data_Engine">
+      <HintPath>..\..\..\..\..\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Data_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>True</Private>

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -100,10 +100,12 @@ namespace BH.Tests.Adapter.IES
         [Description("Test to check if panels are being pushed correctly with 3D shades.")]
         public void PushPanelsWith3DShades()
         {
+            //Arrange objects to push.
             FilterRequest request = new FilterRequest();
             m_PushConfig.ShadesAs3D = true;
             m_PullConfig.ShadesAs3D = true;
             m_PullConfig.PullOpenings = true;
+
             List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 3D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
 
             int count = 0;
@@ -113,6 +115,8 @@ namespace BH.Tests.Adapter.IES
                 count++;
             }
 
+
+            //Push, then pull and sort objects by name.
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig:m_PullConfig).Cast<IBHoMObject>().ToList();
@@ -122,6 +126,8 @@ namespace BH.Tests.Adapter.IES
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
+
+            //Assert objects are identical to the ones pushed.
             for (int i = 0; i < panels.Count; i++)
             {
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
@@ -134,10 +140,12 @@ namespace BH.Tests.Adapter.IES
         [Description("Test to check if panels are being pushed correctly with 2D shades.")]
         public void PushPanelsWith2DShades()
         {
+            //Arrange objects to push.
             FilterRequest request = new FilterRequest();
             m_PushConfig.ShadesAs3D = false;
             m_PullConfig.ShadesAs3D = false;
             m_PullConfig.PullOpenings = true;
+
             List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 2D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
 
             int count = 0;
@@ -147,6 +155,8 @@ namespace BH.Tests.Adapter.IES
                 count++;
             }
 
+
+            //Push, then pull and sort objects by name.
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig: m_PullConfig).Cast<IBHoMObject>().ToList();
@@ -156,6 +166,8 @@ namespace BH.Tests.Adapter.IES
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
+
+            //Assert objects are identical to the ones pushed.
             for (int i = 0; i < panels.Count; i++)
             {
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -133,6 +133,7 @@ namespace BH.Tests.Adapter.IES
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
             }
 
+            pulledPanels.Count().Should().Be(panels.Count, "Wrong number of panels pulled compared to expected.");
             pulledSpaces.Count.Should().Be(14, "Wrong number of spaces pulled compared to expected.");
         }
 
@@ -173,6 +174,7 @@ namespace BH.Tests.Adapter.IES
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
             }
 
+            pulledPanels.Count().Should().Be(panels.Count, "Wrong number of panels pulled compared to expected.");
             pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected."); //As the shades are being pushed, then pulled as 2D, they are not connected to any spaces, so there are 5 fewer spaces.
         }
     }

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -1,5 +1,4 @@
-<<<<<<< HEAD
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
  *
@@ -22,9 +21,6 @@
  */
 
 using BH.Adapter.IES;
-=======
-﻿using BH.Adapter.IES;
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
 using BH.oM.Adapter;
 using BH.oM.Data.Requests;
 using BH.oM.Environment.Elements;
@@ -110,7 +106,6 @@ namespace BH.Tests.Adapter.IES
             m_PullConfig.PullOpenings = true;
             List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 3D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
 
-<<<<<<< HEAD
             int count = 0;
             foreach (Panel panel in panels)
             {
@@ -118,8 +113,6 @@ namespace BH.Tests.Adapter.IES
                 count++;
             }
 
-=======
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig:m_PullConfig).Cast<IBHoMObject>().ToList();
@@ -127,32 +120,13 @@ namespace BH.Tests.Adapter.IES
             List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
 
-<<<<<<< HEAD
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
-=======
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
-            List<Panel> shades = new List<Panel>();
-            foreach (Panel panel in pulledPanels)
-            {
-                if (panel.IsShade())
-                {
-                    shades.Add(panel);
-                }
-            }
-
-<<<<<<< HEAD
-            pulledPanels.Volume().Should().Be(panels.Volume());
             for (int i = 0; i < panels.Count; i++)
             {
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
             }
 
-=======
-            pulledPanels.Count.Should().Be(121, "Wrong number of panels pulled compared to expected.");
-            pulledPanels.OpeningsFromElements().Count.Should().Be(33, "Wrong number of openings pulled compared to expected.");
-            shades.Count.Should().Be(62, "Wrong number of shades being pulled compared to expected.");
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
             pulledSpaces.Count.Should().Be(14, "Wrong number of spaces pulled compared to expected.");
         }
 
@@ -166,7 +140,6 @@ namespace BH.Tests.Adapter.IES
             m_PullConfig.PullOpenings = true;
             List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 2D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
 
-<<<<<<< HEAD
             int count = 0;
             foreach (Panel panel in panels)
             {
@@ -174,8 +147,6 @@ namespace BH.Tests.Adapter.IES
                 count++;
             }
 
-=======
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig: m_PullConfig).Cast<IBHoMObject>().ToList();
@@ -183,22 +154,8 @@ namespace BH.Tests.Adapter.IES
             List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
 
-<<<<<<< HEAD
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
-=======
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
-            List<Panel> shades = new List<Panel>();
-            foreach (Panel panel in pulledPanels)
-            {
-                if (panel.IsShade())
-                {
-                    shades.Add(panel);
-                }
-            }
-
-<<<<<<< HEAD
-            pulledPanels.Volume().Should().Be(panels.Volume());
             for (int i = 0; i < panels.Count; i++)
             {
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
@@ -206,14 +163,5 @@ namespace BH.Tests.Adapter.IES
 
             pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected.");
         }
-=======
-            pulledPanels.Count.Should().Be(121, "Wrong number of panels pulled compared to expected.");
-            pulledPanels.OpeningsFromElements().Count.Should().Be(33, "Wrong number of openings pulled compared to expected.");
-            shades.Count.Should().Be(62, "Wrong number of shades being pulled compared to expected.");
-            pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected.");
-        }
-
-
->>>>>>> 7fdf031b4f3abbc1a97b129a537e5a944de14a64
     }
 }

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -1,4 +1,26 @@
-﻿using BH.Adapter.IES;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Adapter.IES;
 using BH.oM.Adapter;
 using BH.oM.Data.Requests;
 using BH.oM.Environment.Elements;
@@ -84,12 +106,21 @@ namespace BH.Tests.Adapter.IES
             m_PullConfig.PullOpenings = true;
             List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 3D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
 
+            int count = 0;
+            foreach (Panel panel in panels)
+            {
+                panel.Name = count.ToString();
+                count++;
+            }
+
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig:m_PullConfig).Cast<IBHoMObject>().ToList();
 
             List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
+
+            pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
             List<Panel> shades = new List<Panel>();
             foreach (Panel panel in pulledPanels)
@@ -100,9 +131,12 @@ namespace BH.Tests.Adapter.IES
                 }
             }
 
-            pulledPanels.Count.Should().Be(121, "Wrong number of panels pulled compared to expected.");
-            pulledPanels.OpeningsFromElements().Count.Should().Be(33, "Wrong number of openings pulled compared to expected.");
-            shades.Count.Should().Be(62, "Wrong number of shades being pulled compared to expected.");
+            pulledPanels.Volume().Should().Be(panels.Volume());
+            for (int i = 0; i < panels.Count; i++)
+            {
+                pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
+            }
+
             pulledSpaces.Count.Should().Be(14, "Wrong number of spaces pulled compared to expected.");
         }
 
@@ -116,12 +150,21 @@ namespace BH.Tests.Adapter.IES
             m_PullConfig.PullOpenings = true;
             List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 2D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
 
+            int count = 0;
+            foreach (Panel panel in panels)
+            {
+                panel.Name = count.ToString();
+                count++;
+            }
+
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig: m_PullConfig).Cast<IBHoMObject>().ToList();
 
             List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
+
+            pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
             List<Panel> shades = new List<Panel>();
             foreach (Panel panel in pulledPanels)
@@ -132,12 +175,13 @@ namespace BH.Tests.Adapter.IES
                 }
             }
 
-            pulledPanels.Count.Should().Be(121, "Wrong number of panels pulled compared to expected.");
-            pulledPanels.OpeningsFromElements().Count.Should().Be(33, "Wrong number of openings pulled compared to expected.");
-            shades.Count.Should().Be(62, "Wrong number of shades being pulled compared to expected.");
+            pulledPanels.Volume().Should().Be(panels.Volume());
+            for (int i = 0; i < panels.Count; i++)
+            {
+                pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
+            }
+
             pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected.");
         }
-
-
     }
 }

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -1,0 +1,143 @@
+﻿using BH.Adapter.IES;
+using BH.oM.Adapter;
+using BH.oM.Data.Requests;
+using BH.oM.Environment.Elements;
+using BH.oM.Environment.IES;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using BH.Engine.Environment;
+using BH.oM.Base;
+using BH.Engine.Adapter;
+using BH.oM.Geometry;
+using NUnit.Framework;
+using BH.Engine.Base;
+
+namespace BH.Tests.Adapter.IES
+{
+    public class PushTests
+    {
+        IESAdapter m_Adapter;
+        PushConfigIES m_PushConfig;
+        PullConfigIES m_PullConfig;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            string currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            List<string> paths = currentDirectory.Split('\\').ToList();
+            paths = paths.Take(paths.IndexOf(".ci") + 2).ToList();
+            string ModelsPath = Path.Join(string.Join("\\", paths), "Models");
+            FileSettings file = new FileSettings()
+            {
+                Directory = ModelsPath,
+                FileName = "PushedModel.gem"
+            };
+            m_Adapter = new IESAdapter();
+            m_PushConfig = new PushConfigIES()
+            {
+                PlanarTolerance = 1.0e-6,
+                AngleTolerance = Tolerance.Angle,
+                DecimalPlaces = 6,
+                DistanceTolerance = Tolerance.MacroDistance,
+                File = file
+            };
+            m_PullConfig = new PullConfigIES()
+            {
+                AngleTolerance = Tolerance.Angle,
+                DistanceTolerance = Tolerance.Distance,
+                File = file
+            };
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            Engine.Base.Compute.ClearCurrentEvents();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            File.Delete(m_PushConfig.File.GetFullFileName());
+            var events = Engine.Base.Query.CurrentEvents();
+            if (events.Any())
+            {
+                Console.WriteLine("BHoM Events raised during execution:");
+                foreach (var ev in events)
+                {
+                    Console.WriteLine($"{ev.Type}: {ev.Message}");
+                }
+            }
+        }
+
+        [Test]
+        [Description("Test to check if panels are being pushed correctly with 3D shades.")]
+        public void PushPanelsWith3DShades()
+        {
+            FilterRequest request = new FilterRequest();
+            m_PushConfig.ShadesAs3D = true;
+            m_PullConfig.ShadesAs3D = true;
+            m_PullConfig.PullOpenings = true;
+            List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 3D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
+
+            m_Adapter.Push(panels, actionConfig: m_PushConfig);
+
+            List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig:m_PullConfig).Cast<IBHoMObject>().ToList();
+
+            List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
+            List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
+
+            List<Panel> shades = new List<Panel>();
+            foreach (Panel panel in pulledPanels)
+            {
+                if (panel.IsShade())
+                {
+                    shades.Add(panel);
+                }
+            }
+
+            pulledPanels.Count.Should().Be(121, "Wrong number of panels pulled compared to expected.");
+            pulledPanels.OpeningsFromElements().Count.Should().Be(33, "Wrong number of openings pulled compared to expected.");
+            shades.Count.Should().Be(62, "Wrong number of shades being pulled compared to expected.");
+            pulledSpaces.Count.Should().Be(14, "Wrong number of spaces pulled compared to expected.");
+        }
+
+        [Test]
+        [Description("Test to check if panels are being pushed correctly with 2D shades.")]
+        public void PushPanelsWith2DShades()
+        {
+            FilterRequest request = new FilterRequest();
+            m_PushConfig.ShadesAs3D = false;
+            m_PullConfig.ShadesAs3D = false;
+            m_PullConfig.PullOpenings = true;
+            List<Panel> panels = Engine.Adapters.File.Compute.ReadFromJsonFile(Path.Combine(m_PullConfig.File.Directory, "Test Model 2D Shades.json"), true).Where(x => x.GetType() == typeof(Panel)).Cast<Panel>().ToList();
+
+            m_Adapter.Push(panels, actionConfig: m_PushConfig);
+
+            List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig: m_PullConfig).Cast<IBHoMObject>().ToList();
+
+            List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
+            List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
+
+            List<Panel> shades = new List<Panel>();
+            foreach (Panel panel in pulledPanels)
+            {
+                if (panel.IsShade())
+                {
+                    shades.Add(panel);
+                }
+            }
+
+            pulledPanels.Count.Should().Be(121, "Wrong number of panels pulled compared to expected.");
+            pulledPanels.OpeningsFromElements().Count.Should().Be(33, "Wrong number of openings pulled compared to expected.");
+            shades.Count.Should().Be(62, "Wrong number of shades being pulled compared to expected.");
+            pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected.");
+        }
+
+
+    }
+}

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -161,7 +161,7 @@ namespace BH.Tests.Adapter.IES
                 pulledPanels[i].IsIdentical(panels[i]).Should().BeTrue($"The panel pulled with name: {pulledPanels[i].Name}, was not identical to the panel originally pushed with the same name.");
             }
 
-            pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected.");
+            pulledSpaces.Count.Should().Be(9, "Wrong number of spaces pulled compared to expected."); //As the shades are being pushed, then pulled as 2D, they are not connected to any spaces, so there are 5 fewer spaces.
         }
     }
 }

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -58,7 +58,9 @@ namespace BH.Tests.Adapter.IES
                 Directory = ModelsPath,
                 FileName = "PushedModel.gem"
             };
+
             m_Adapter = new IESAdapter();
+
             m_PushConfig = new PushConfigIES()
             {
                 PlanarTolerance = 1.0e-6,
@@ -67,6 +69,7 @@ namespace BH.Tests.Adapter.IES
                 DistanceTolerance = Tolerance.MacroDistance,
                 File = file
             };
+
             m_PullConfig = new PullConfigIES()
             {
                 AngleTolerance = Tolerance.Angle,
@@ -115,7 +118,6 @@ namespace BH.Tests.Adapter.IES
                 count++;
             }
 
-
             //Push, then pull and sort objects by name.
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
@@ -125,7 +127,6 @@ namespace BH.Tests.Adapter.IES
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
-
 
             //Assert objects are identical to the ones pushed.
             for (int i = 0; i < panels.Count; i++)
@@ -156,7 +157,6 @@ namespace BH.Tests.Adapter.IES
                 count++;
             }
 
-
             //Push, then pull and sort objects by name.
             m_Adapter.Push(panels, actionConfig: m_PushConfig);
 
@@ -166,7 +166,6 @@ namespace BH.Tests.Adapter.IES
             List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
-
 
             //Assert objects are identical to the ones pushed.
             for (int i = 0; i < panels.Count; i++)

--- a/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
+++ b/.ci/unit-tests/IES_Adapter_Test/PushTests.cs
@@ -117,8 +117,8 @@ namespace BH.Tests.Adapter.IES
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig:m_PullConfig).Cast<IBHoMObject>().ToList();
 
-            List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
-            List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
+            List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs);
+            List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 
@@ -151,8 +151,8 @@ namespace BH.Tests.Adapter.IES
 
             List<IBHoMObject> objs = m_Adapter.Pull(request, actionConfig: m_PullConfig).Cast<IBHoMObject>().ToList();
 
-            List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs).Cast<Space>().ToList();
-            List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs).Cast<Panel>().ToList();
+            List<Space> pulledSpaces = BH.Engine.Environment.Query.Spaces(objs);
+            List<Panel> pulledPanels = BH.Engine.Environment.Query.Panels(objs);
 
             pulledPanels = BH.Engine.Data.Query.OrderBy(pulledPanels, "Name");
 


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #236 

 <!-- Add short description of what has been fixed -->
Functional tests for the the push functionality have been created that test the following:
- Pushing panels to GEM with 3D shades. Tests if the panels as they are in the json file are identical to the ones pushed and pulled, and checks that the correct number of spaces were created.
- Pushing panels to GEM with 2D shades with openings. Tests as above.

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
JSON files created in #237 used to push to a temporary file for testing.