### PR TITLE
Adapter gem file reading now updated to support 2024 onward files

### DIFF
--- a/IES_Adapter/CRUD/Read.cs
+++ b/IES_Adapter/CRUD/Read.cs
@@ -113,9 +113,11 @@ namespace BH.Adapter.IES
 
             int linesToSkip = 10;
 
-            if (iesStrings.First() != "LAYER") //Check if it is a 2019 GEM file
+            // Look for the first line that starts with "LAYER" (some newer GEM files have header lines before it)
+            int firstLayerIndex = iesStrings.FindIndex(s => s != null && s.StartsWith("LAYER", StringComparison.Ordinal));
+            if (firstLayerIndex > 0) // there are header lines before the first LAYER
             {
-                iesStrings.RemoveRange(0, 4);
+                iesStrings.RemoveRange(0, firstLayerIndex);
                 linesToSkip = 12;
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #260 

Updated the entry point of reading .gem file to be dependant on the first instance of `LAYER`

 <!-- Add short description of what has been fixed -->

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Any .gem file ,before and/or after 2024 version would be worth testing
Use the adapter to read the gem file, check it runs without error 

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->